### PR TITLE
Add support for rewriting multiple references to the same asset

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    * \\s* - Any amount of white space
    * ( - Starts the first capture group
    * [^"\'()=]* - Do not match any of ^"'()= 0 or more times
-   * [^"\'()\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
+   * [^"\'()\\\\>=]* - Do not match any of ^"'()\>= 0 or more times - Explicitly add \ here because of handlebars compilation
    * ) - End first capture group
    * (\\?[^"\')> ]*)? - Allow for query parameters to be present after the URL of an asset
    * \\s* - Any amount of white space
@@ -106,7 +106,7 @@ AssetRewrite.prototype.rewriteAssetPath = function (string, assetPath, replaceme
    * ["\')> ] - Match one of "'( > exactly one time
    */
 
-  var re = new RegExp('["\'(=]\\s*([^"\'()=]*' + escapeRegExp(assetPath) + '[^"\'()\\>=]*)(\\?[^"\')> ]*)?\\s*\\\\*\\s*["\')> ]', 'g');
+  var re = new RegExp('["\'(=]\\s*([^"\'()=]*' + escapeRegExp(assetPath) + '[^"\'()\\\\>=]*)(\\?[^"\')> ]*)?\\s*\\\\*\\s*["\')> ]', 'g');
   var match = null;
   /*
    * This is to ignore matches that should not be changed

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -233,4 +233,37 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     })
   });
+
+  it('handles escaped quotes', function () {
+    var sourcePath = 'tests/fixtures/escaped-path';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      replaceExtensions: ['js'],
+      assetMap: {
+        'assets/images/foo.png': 'assets/images/foo-fingerprint.png',
+        'assets/images/bar.png': 'assets/images/bar-fingerprint.png',
+      },
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('handles escaped quotes with prepend', function () {
+    var sourcePath = 'tests/fixtures/escaped-path-prepend';
+    var node = new AssetRewrite(sourcePath + '/input', {
+      replaceExtensions: ['js'],
+      assetMap: {
+        'assets/images/foo.png': 'assets/images/foo-fingerprint.png',
+        'assets/images/bar.png': 'assets/images/bar-fingerprint.png',
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function (graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -266,4 +266,41 @@ describe('broccoli-asset-rev', function() {
       confirmOutput(graph.directory, sourcePath + '/output');
     });
   });
+
+  it('handles files containing duplicates of the same path', function () {
+    var sourcePath = 'tests/fixtures/duplicate';
+    var node = AssetRewrite(sourcePath + '/input', {
+      replaceExtensions: ['css', 'html', 'js'],
+      assetMap: {
+        'foo/bar/a.js': 'foo/bar/a.js',
+        'foo/bar/b.js': 'foo/bar/b-fingerprint.js',
+        'assets/images/a.png': 'assets/images/a.png',
+        'assets/images/b.png': 'assets/images/b-fingerprint.png'
+      }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
+
+  it('handles files containing duplicates of the same path with prepend', function () {
+    var sourcePath = 'tests/fixtures/duplicate-prepend';
+    var node = AssetRewrite(sourcePath + '/input', {
+      replaceExtensions: ['css', 'html', 'js'],
+      assetMap: {
+        'foo/bar/a.js': 'foo/bar/a.js',
+        'foo/bar/b.js': 'foo/bar/b-fingerprint.js',
+        'assets/images/a.png': 'assets/images/a.png',
+        'assets/images/b.png': 'assets/images/b-fingerprint.png'
+      },
+      prepend: 'https://cloudfront.net/'
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      confirmOutput(graph.directory, sourcePath + '/output');
+    });
+  });
 });

--- a/tests/fixtures/duplicate-prepend/input/assets/raw-string.js
+++ b/tests/fixtures/duplicate-prepend/input/assets/raw-string.js
@@ -1,0 +1,14 @@
+var assetsA = [
+  "images/a.png",
+  'images/a.png',
+  "./images/a.png",
+  "images/a.png",
+];
+var stringfiedAssetsA = "[\"images/a.png\",'images/a.png',\"images/a.png\"]";
+
+var assetsB = [
+  "images/b.png",
+  'images/b.png',
+  "images/b.png",
+];
+var stringfiedAssetsB = "[\"images/b.png\",'images/b.png',\"images/b.png\"]";

--- a/tests/fixtures/duplicate-prepend/input/assets/similar-path.html
+++ b/tests/fixtures/duplicate-prepend/input/assets/similar-path.html
@@ -1,0 +1,5 @@
+<img src="images/a.png"/>
+<img src="./images/a.png"/>
+
+<img src="images/b.png"/>
+<img src="./images/b.png"/>

--- a/tests/fixtures/duplicate-prepend/input/assets/url-in-styles.css
+++ b/tests/fixtures/duplicate-prepend/input/assets/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(images/b.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(images/b.png)}

--- a/tests/fixtures/duplicate-prepend/input/script-tag.html
+++ b/tests/fixtures/duplicate-prepend/input/script-tag.html
@@ -1,0 +1,9 @@
+<script src=foo/bar/a.js></script>
+<script src="foo/bar/a.js"></script>
+<script src=foo/bar/a.js></script>
+<script src="foo/bar/a.js"></script>
+
+<script src=foo/bar/b.js></script>
+<script src="foo/bar/b.js"></script>
+<script src=foo/bar/b.js></script>
+<script src="foo/bar/b.js"></script>

--- a/tests/fixtures/duplicate-prepend/input/similar-path.html
+++ b/tests/fixtures/duplicate-prepend/input/similar-path.html
@@ -1,0 +1,5 @@
+<img src="assets/images/a.png"/>
+<img src="/assets/images/a.png"/>
+
+<img src="assets/images/b.png"/>
+<img src="/assets/images/b.png"/>

--- a/tests/fixtures/duplicate-prepend/input/url-in-styles.css
+++ b/tests/fixtures/duplicate-prepend/input/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(assets/images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(assets/images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(assets/images/b.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(assets/images/b.png)}

--- a/tests/fixtures/duplicate-prepend/output/assets/raw-string.js
+++ b/tests/fixtures/duplicate-prepend/output/assets/raw-string.js
@@ -1,0 +1,14 @@
+var assetsA = [
+  "https://cloudfront.net/assets/images/a.png",
+  'https://cloudfront.net/assets/images/a.png',
+  "https://cloudfront.net/assets/images/a.png",
+  "https://cloudfront.net/assets/images/a.png",
+];
+var stringfiedAssetsA = "[\"https://cloudfront.net/assets/images/a.png\",'https://cloudfront.net/assets/images/a.png',\"https://cloudfront.net/assets/images/a.png\"]";
+
+var assetsB = [
+  "https://cloudfront.net/assets/images/b-fingerprint.png",
+  'https://cloudfront.net/assets/images/b-fingerprint.png',
+  "https://cloudfront.net/assets/images/b-fingerprint.png",
+];
+var stringfiedAssetsB = "[\"https://cloudfront.net/assets/images/b-fingerprint.png\",'https://cloudfront.net/assets/images/b-fingerprint.png',\"https://cloudfront.net/assets/images/b-fingerprint.png\"]";

--- a/tests/fixtures/duplicate-prepend/output/assets/similar-path.html
+++ b/tests/fixtures/duplicate-prepend/output/assets/similar-path.html
@@ -1,0 +1,5 @@
+<img src="https://cloudfront.net/assets/images/a.png"/>
+<img src="https://cloudfront.net/assets/images/a.png"/>
+
+<img src="https://cloudfront.net/assets/images/b-fingerprint.png"/>
+<img src="https://cloudfront.net/assets/images/b-fingerprint.png"/>

--- a/tests/fixtures/duplicate-prepend/output/assets/url-in-styles.css
+++ b/tests/fixtures/duplicate-prepend/output/assets/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(https://cloudfront.net/assets/images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(https://cloudfront.net/assets/images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(https://cloudfront.net/assets/images/b-fingerprint.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(https://cloudfront.net/assets/images/b-fingerprint.png)}

--- a/tests/fixtures/duplicate-prepend/output/script-tag.html
+++ b/tests/fixtures/duplicate-prepend/output/script-tag.html
@@ -1,0 +1,9 @@
+<script src=https://cloudfront.net/foo/bar/a.js></script>
+<script src="https://cloudfront.net/foo/bar/a.js"></script>
+<script src=https://cloudfront.net/foo/bar/a.js></script>
+<script src="https://cloudfront.net/foo/bar/a.js"></script>
+
+<script src=https://cloudfront.net/foo/bar/b-fingerprint.js></script>
+<script src="https://cloudfront.net/foo/bar/b-fingerprint.js"></script>
+<script src=https://cloudfront.net/foo/bar/b-fingerprint.js></script>
+<script src="https://cloudfront.net/foo/bar/b-fingerprint.js"></script>

--- a/tests/fixtures/duplicate-prepend/output/similar-path.html
+++ b/tests/fixtures/duplicate-prepend/output/similar-path.html
@@ -1,0 +1,5 @@
+<img src="https://cloudfront.net/assets/images/a.png"/>
+<img src="https://cloudfront.net/assets/images/a.png"/>
+
+<img src="https://cloudfront.net/assets/images/b-fingerprint.png"/>
+<img src="https://cloudfront.net/assets/images/b-fingerprint.png"/>

--- a/tests/fixtures/duplicate-prepend/output/url-in-styles.css
+++ b/tests/fixtures/duplicate-prepend/output/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(https://cloudfront.net/assets/images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(https://cloudfront.net/assets/images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(https://cloudfront.net/assets/images/b-fingerprint.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(https://cloudfront.net/assets/images/b-fingerprint.png)}

--- a/tests/fixtures/duplicate/input/assets/raw-string.js
+++ b/tests/fixtures/duplicate/input/assets/raw-string.js
@@ -1,0 +1,14 @@
+var assetsA = [
+  "images/a.png",
+  'images/a.png',
+  "./images/a.png",
+  "images/a.png",
+];
+var stringfiedAssetsA = "[\"images/a.png\",'images/a.png',\"images/a.png\"]";
+
+var assetsB = [
+  "images/b.png",
+  'images/b.png',
+  "images/b.png",
+];
+var stringfiedAssetsB = "[\"images/b.png\",'images/b.png',\"images/b.png\"]";

--- a/tests/fixtures/duplicate/input/assets/similar-path.html
+++ b/tests/fixtures/duplicate/input/assets/similar-path.html
@@ -1,0 +1,5 @@
+<img src="images/a.png"/>
+<img src="./images/a.png"/>
+
+<img src="images/b.png"/>
+<img src="./images/b.png"/>

--- a/tests/fixtures/duplicate/input/assets/url-in-styles.css
+++ b/tests/fixtures/duplicate/input/assets/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(images/b.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(images/b.png)}

--- a/tests/fixtures/duplicate/input/script-tag.html
+++ b/tests/fixtures/duplicate/input/script-tag.html
@@ -1,0 +1,9 @@
+<script src=foo/bar/a.js></script>
+<script src="foo/bar/a.js"></script>
+<script src=foo/bar/a.js></script>
+<script src="foo/bar/a.js"></script>
+
+<script src=foo/bar/b.js></script>
+<script src="foo/bar/b.js"></script>
+<script src=foo/bar/b.js></script>
+<script src="foo/bar/b.js"></script>

--- a/tests/fixtures/duplicate/input/similar-path.html
+++ b/tests/fixtures/duplicate/input/similar-path.html
@@ -1,0 +1,5 @@
+<img src="assets/images/a.png"/>
+<img src="/assets/images/a.png"/>
+
+<img src="assets/images/b.png"/>
+<img src="/assets/images/b.png"/>

--- a/tests/fixtures/duplicate/input/url-in-styles.css
+++ b/tests/fixtures/duplicate/input/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(assets/images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(assets/images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(assets/images/b.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(assets/images/b.png)}

--- a/tests/fixtures/duplicate/output/assets/raw-string.js
+++ b/tests/fixtures/duplicate/output/assets/raw-string.js
@@ -1,0 +1,14 @@
+var assetsA = [
+  "images/a.png",
+  'images/a.png',
+  "./images/a.png",
+  "images/a.png",
+];
+var stringfiedAssetsA = "[\"images/a.png\",'images/a.png',\"images/a.png\"]";
+
+var assetsB = [
+  "images/b-fingerprint.png",
+  'images/b-fingerprint.png',
+  "images/b-fingerprint.png",
+];
+var stringfiedAssetsB = "[\"images/b-fingerprint.png\",'images/b-fingerprint.png',\"images/b-fingerprint.png\"]";

--- a/tests/fixtures/duplicate/output/assets/similar-path.html
+++ b/tests/fixtures/duplicate/output/assets/similar-path.html
@@ -1,0 +1,5 @@
+<img src="images/a.png"/>
+<img src="./images/a.png"/>
+
+<img src="images/b-fingerprint.png"/>
+<img src="./images/b-fingerprint.png"/>

--- a/tests/fixtures/duplicate/output/assets/url-in-styles.css
+++ b/tests/fixtures/duplicate/output/assets/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(images/b-fingerprint.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(images/b-fingerprint.png)}

--- a/tests/fixtures/duplicate/output/script-tag.html
+++ b/tests/fixtures/duplicate/output/script-tag.html
@@ -1,0 +1,9 @@
+<script src=foo/bar/a.js></script>
+<script src="foo/bar/a.js"></script>
+<script src=foo/bar/a.js></script>
+<script src="foo/bar/a.js"></script>
+
+<script src=foo/bar/b-fingerprint.js></script>
+<script src="foo/bar/b-fingerprint.js"></script>
+<script src=foo/bar/b-fingerprint.js></script>
+<script src="foo/bar/b-fingerprint.js"></script>

--- a/tests/fixtures/duplicate/output/similar-path.html
+++ b/tests/fixtures/duplicate/output/similar-path.html
@@ -1,0 +1,5 @@
+<img src="assets/images/a.png"/>
+<img src="/assets/images/a.png"/>
+
+<img src="assets/images/b-fingerprint.png"/>
+<img src="/assets/images/b-fingerprint.png"/>

--- a/tests/fixtures/duplicate/output/url-in-styles.css
+++ b/tests/fixtures/duplicate/output/url-in-styles.css
@@ -1,0 +1,5 @@
+.sample-img1a{width:50px;height:50px;background-image:url(assets/images/a.png)}
+.sample-img2a{width:10px;height:10px;background-image:url(assets/images/a.png)}
+
+.sample-img1b{width:50px;height:50px;background-image:url(assets/images/b-fingerprint.png)}
+.sample-img2b{width:10px;height:10px;background-image:url(assets/images/b-fingerprint.png)}

--- a/tests/fixtures/escaped-path-prepend/input/app-template.js
+++ b/tests/fixtures/escaped-path-prepend/input/app-template.js
@@ -1,0 +1,1 @@
+export default {"id":"F1vwmGpW","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"assets/images/bar.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/my-app"}};

--- a/tests/fixtures/escaped-path-prepend/input/assets/double-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path-prepend/input/assets/double-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {"id":"xI+Em9Xk","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"images/foo.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/info-box"}};

--- a/tests/fixtures/escaped-path-prepend/input/assets/single-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path-prepend/input/assets/single-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {'id':'xI+Em9Xk','block':'{\'symbols\':[],\'statements\':[[6,\'img\'],[9,\'src\',\'images/foo.png\'],[7],[8]],\'hasEval\':false}','meta':{'specifier':'template:/my-app/components/info-box'}};

--- a/tests/fixtures/escaped-path-prepend/output/app-template.js
+++ b/tests/fixtures/escaped-path-prepend/output/app-template.js
@@ -1,0 +1,1 @@
+export default {"id":"F1vwmGpW","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"https://cloudfront.net/assets/images/bar-fingerprint.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/my-app"}};

--- a/tests/fixtures/escaped-path-prepend/output/assets/double-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path-prepend/output/assets/double-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {"id":"xI+Em9Xk","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"https://cloudfront.net/assets/images/foo-fingerprint.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/info-box"}};

--- a/tests/fixtures/escaped-path-prepend/output/assets/single-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path-prepend/output/assets/single-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {'id':'xI+Em9Xk','block':'{\'symbols\':[],\'statements\':[[6,\'img\'],[9,\'src\',\'https://cloudfront.net/assets/images/foo-fingerprint.png\'],[7],[8]],\'hasEval\':false}','meta':{'specifier':'template:/my-app/components/info-box'}};

--- a/tests/fixtures/escaped-path/input/app-template.js
+++ b/tests/fixtures/escaped-path/input/app-template.js
@@ -1,0 +1,1 @@
+export default {"id":"F1vwmGpW","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"assets/images/bar.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/my-app"}};

--- a/tests/fixtures/escaped-path/input/assets/double-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path/input/assets/double-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {"id":"xI+Em9Xk","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"images/foo.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/info-box"}};

--- a/tests/fixtures/escaped-path/input/assets/single-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path/input/assets/single-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {'id':'xI+Em9Xk','block':'{\'symbols\':[],\'statements\':[[6,\'img\'],[9,\'src\',\'images/foo.png\'],[7],[8]],\'hasEval\':false}','meta':{'specifier':'template:/my-app/components/info-box'}};

--- a/tests/fixtures/escaped-path/output/app-template.js
+++ b/tests/fixtures/escaped-path/output/app-template.js
@@ -1,0 +1,1 @@
+export default {"id":"F1vwmGpW","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"assets/images/bar-fingerprint.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/my-app"}};

--- a/tests/fixtures/escaped-path/output/assets/double-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path/output/assets/double-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {"id":"xI+Em9Xk","block":"{\"symbols\":[],\"statements\":[[6,\"img\"],[9,\"src\",\"images/foo-fingerprint.png\"],[7],[8]],\"hasEval\":false}","meta":{"specifier":"template:/my-app/components/info-box"}};

--- a/tests/fixtures/escaped-path/output/assets/single-quote-compiled-hbs.js
+++ b/tests/fixtures/escaped-path/output/assets/single-quote-compiled-hbs.js
@@ -1,0 +1,1 @@
+export default {'id':'xI+Em9Xk','block':'{\'symbols\':[],\'statements\':[[6,\'img\'],[9,\'src\',\'images/foo-fingerprint.png\'],[7],[8]],\'hasEval\':false}','meta':{'specifier':'template:/my-app/components/info-box'}};


### PR DESCRIPTION
Fixes #39 and #59.

Previously, when a matching asset path was found, the matched path was replaced globally with `replaceString`. When a file contains multiple references to the same (or similar) asset paths, the matching part of the path may be replaced globally multiple times. In the case where there is a prepend string and no fingerprint, the resulting path may contain duplicate segments.

This PR uses `String.prototype.replace` to allow for local replacements of each matched asset path. This approach removes the possibility that a path could be replaced multiple times. It also ensures that each matched path is replaced with the correct `replaceString`.

Additionally, new tests have been added for duplicate assets paths and escaped quotation marks (e.g., compiled Glimmer templates)