### PR TITLE
Allow opt-in to caching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ var assetNode = new AssetRewrite(node, {
   - `prepend` - Default: `''` - A string to prepend to all of the assets. Useful for CDN urls like `https://subdomain.cloudfront.net/`
   - `ignore` - Default: `[]` - Ignore files from being rewritten.
   - `annotation` - Default: null - A human-readable description for this plugin instance.
+  - `enableCaching` - Default: false - Setting to true will enable caching but may cause problems in typical usage with broccoli-asset-rev.
 
 ## Requirements
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ class AssetRewrite extends Filter {
 
 
   processAndCacheFile(srcDir, destDir, relativePath) {
-    if (!this.enableCaching) {
+    let shouldResetCache = !this.enableCaching;
+    if (shouldResetCache) {
       this._cache = new Cache();
     }
     return super.processAndCacheFile(...arguments);

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ class AssetRewrite extends Filter {
     this.enableCaching = options.enableCaching || false;
 
     this.assetMapKeys = null;
+    this._debugProcessedCount = 0;
   }
 
 
@@ -164,7 +165,7 @@ class AssetRewrite extends Filter {
         newString = this.rewriteAssetPath(newString, pathDiff, replacementDiff);
       }
     }
-
+    this._debugProcessedCount++;
     return newString;
   }
 

--- a/index.js
+++ b/index.js
@@ -28,13 +28,16 @@ class AssetRewrite extends Filter {
     this.assetMap = options.assetMap || {};
     this.prepend = options.prepend || '';
     this.ignore = options.ignore || []; // files to ignore
+    this.enableCaching = options.enableCaching || false;
 
     this.assetMapKeys = null;
   }
 
 
   processAndCacheFile(srcDir, destDir, relativePath) {
-    this._cache = new Cache();
+    if (!this.enableCaching) {
+      this._cache = new Cache();
+    }
     return super.processAndCacheFile(...arguments);
   }
 

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ class AssetRewrite extends Filter {
     return newString;
   }
 
-    generateAssetMapKeys () {
+  generateAssetMapKeys () {
     var keys = Object.keys(this.assetMap);
 
     keys.sort(function (a, b) {

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -58,6 +58,13 @@ describe("broccoli-asset-rev", function () {
     });
     await output.build();
 
+    expect(output.changes()).to.deep.equal({
+      "encoded-meta-tag.html": "create",
+      "fonts.css": "create",
+      "quoted-script-tag.html": "create",
+      "unquoted-script-tag.html": "create",
+      "unquoted-url-in-styles.css": "create",
+    });
     expect(output.read()).to.deep.equal({
       "encoded-meta-tag.html": `<meta name="ember-sample/config/environment" content="%7B%22modulePrefix%22%3A%22ember-sample%22%2C%22environment%22%3A%22development%22%2C%22baseURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22marked%22%3A%7B%22js%22%3A%22/foo/bar/widget.js%22%2C%22highlights%22%3Afalse%7D%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22ember-sample%22%2C%22version%22%3A%220.0.0.bb29331f%22%7D%2C%22contentSecurityPolicyHeader%22%3A%22Content-Security-Policy-Report-Only%22%2C%22contentSecurityPolicy%22%3A%7B%22default-src%22%3A%22%27none%27%22%2C%22script-src%22%3A%22%27self%27%20%27unsafe-eval%27%22%2C%22font-src%22%3A%22%27self%27%22%2C%22connect-src%22%3A%22%27self%27%22%2C%22img-src%22%3A%22%27self%27%22%2C%22style-src%22%3A%22%27self%27%22%2C%22media-src%22%3A%22%27self%27%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />`,
       "fonts.css": `@font-face {
@@ -102,6 +109,12 @@ describe("broccoli-asset-rev", function () {
 
     await output.build();
 
+    expect(output.changes()).to.deep.equal({
+      "ignore-this-file": "create",
+      "quoted-script-tag.html": "create",
+      "unquoted-script-tag.html": "create",
+      "unquoted-url-in-styles.css": "create"
+    });
     expect(output.read()).to.deep.equal({
       "ignore-this-file": `<script src="foo/bar/widget.js"></script>`,
       "quoted-script-tag.html": `<script src="blahzorz-1.js"></script>`,
@@ -138,6 +151,13 @@ describe("broccoli-asset-rev", function () {
 
     await output.build();
 
+    expect(output.changes()).to.deep.equal({
+      "assets/": "mkdir",
+      "assets/url-in-styles.css": "create",
+      "quoted-script-tag.html": "create",
+      "unquoted-script-tag.html": "create",
+      "unquoted-url-in-styles.css": "create",
+    });
     expect(output.read()).to.deep.equal({
       assets: {
         "url-in-styles.css": `.sample-img{width:50px;height:50px;background-image:url('images/foobar-fingerprint.png')}
@@ -181,6 +201,14 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "assets/": "mkdir",
+      "assets/no-fingerprint.html": "create",
+      "assets/url-in-styles.css": "create",
+      "quoted-script-tag.html": "create",
+      "unquoted-script-tag.html": "create",
+      "unquoted-url-in-styles.css": "create"
+    });
     expect(output.read()).to.deep.equal({
       assets: {
         "no-fingerprint.html": `<script src="https://cloudfront.net/dont/fingerprint/me.js"></script>`,
@@ -223,6 +251,9 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "styles.css": "create"
+    });
     expect(output.read()).to.deep.equal({
       "styles.css": `@font-face {
         font-family: 'RobotoRegular';
@@ -254,6 +285,10 @@ describe("broccoli-asset-rev", function () {
       "sample.js": `(function x(){return 42})//# sourceMappingURL=the.map`,
     });
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "abs.js": "create",
+      "sample.js": "create",
+    });
     expect(output.read()).to.deep.equal({
       "abs.js": `(function x(){return 42})//# sourceMappingURL=http://cdn.absolute.com/other-map`,
       "sample.js": `(function x(){return 42})//# sourceMappingURL=the-other-map`,
@@ -277,6 +312,10 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "abs.js": "create",
+      "sample.js": "create"
+    });
     expect(output.read()).to.deep.equal({
       "abs.js": `(function x(){return 42})//# sourceMappingURL=http://cdn.absolute.com/other-map`,
       "sample.js": `(function x(){return 42})//# sourceMappingURL=https://cloudfront.net/the-other-map`,
@@ -297,6 +336,10 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "svg-tag.html": "create",
+      "unquoted-url-in-styles.css": "create"
+    });
     expect(output.read()).to.deep.equal({
       "svg-tag.html": `<svg><use xlink:href="/images/fingerprinted-defs.svg#plus"></use></svg>`,
       "unquoted-url-in-styles.css": `.sample-img{width:50px;height:50px;background-image:url(/images/fingerprinted-defs.svg#plus)}`,
@@ -318,6 +361,10 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "svg-tag.html": "create",
+      "unquoted-url-in-styles.css": "create"
+    });
     expect(output.read()).to.deep.equal({
       "svg-tag.html": `<svg><use xlink:href="https://cloudfront.net/images/fingerprinted-defs.svg#plus"></use></svg>`,
       "unquoted-url-in-styles.css": `.sample-img{width:50px;height:50px;background-image:url(https://cloudfront.net/images/fingerprinted-defs.svg#plus)}`,
@@ -341,6 +388,11 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "img-tag.html": "create",
+      "no-fingerprint.html": "create",
+      "unquoted-url-in-styles.css": "create",
+    });
     expect(output.read()).to.deep.equal({
       "img-tag.html": `<img src="https://cloudfront.net/my-image-fingerprinted.png">`,
       "no-fingerprint.html": `<script src="https://cloudfront.net/dont/fingerprint/me.js"></script>`,
@@ -366,6 +418,9 @@ describe("broccoli-asset-rev", function () {
       `,
     });
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "script-tag-with-query-parameters.html": "create"
+    });
     expect(output.read()).to.deep.equal({
       "script-tag-with-query-parameters.html": `<script src="foo/bar/fingerprinted-widget.js?hello=world"></script>
       <script src="foo/bar/fingerprinted-widget.js?hello=world&amp;foo=bar"></script>
@@ -392,6 +447,9 @@ describe("broccoli-asset-rev", function () {
     });
     const output = createBuilder(subject);
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "test-support.js": "create"
+    });
     expect(output.read()).to.deep.equal(fixtures.read("js-perf/output"));
   });
 
@@ -422,6 +480,9 @@ describe("broccoli-asset-rev", function () {
     });
 
     await output.build();
+    expect(output.changes()).to.deep.equal({
+      "snippet.js": "create"
+    });
     expect(output.read()).to.deep.equal({
       "snippet.js": `/**
       here's some code.

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -438,4 +438,42 @@ describe("broccoli-asset-rev", function () {
       `,
     });
   });
+
+  it('can optionally use caching', async function() {
+    this.timeout(500);
+    let fixturesPath = `${__dirname}/fixtures`;
+    let fixtures = fromDir(fixturesPath);
+    const input = await createTempDir();
+    input.write(fixtures.read("js-perf/input"));
+
+    const subject = new AssetRewrite(input.path(), {
+      assetMap: {
+        assetMap: JSON.parse(
+          fs.readFileSync(`${fixturesPath}/js-perf/asset-map.json`)
+        ),
+        replaceExtensions: ["js"],
+        enableCaching: true
+      },
+    });
+    const output = createBuilder(subject);
+
+    const run1Start = process.hrtime();
+    await output.build();
+    let expectedTestSupportOutput = fs.readFileSync(`${fixturesPath}/js-perf/output/test-support.js`).toString();
+    const run1End = process.hrtime(run1Start);
+    expect(output.read()).to.deep.equal({
+      'test-support.js': expectedTestSupportOutput
+    });
+
+    const run2Start = process.hrtime();
+    await output.build();
+    const run2End = process.hrtime(run2Start);
+    expect(output.read()).to.deep.equal({
+      'test-support.js': expectedTestSupportOutput
+    });
+    
+    const run1DurationMs = (run1End[0] * 1000000000 + run1End[1]) / 1000000;
+    const run2DurationMs = (run2End[0] * 1000000000 + run2End[1]) / 1000000;
+    expect(run2DurationMs).to.be.below(run1DurationMs * .75, `cache should make second run (${run2DurationMs}ms) at least 25% faster than first run (${run1DurationMs}ms)`);
+  });
 });


### PR DESCRIPTION
- Caching has historically been disabled for this plugin because of the difficulty of managing cache keys that would be invalidated by the contents of assets changing. Using this plugin in other contexts, such as broccoli-asset-prepend, don't share this problem, and should be able to enable caching to improve performance.